### PR TITLE
高さの単位であるvhとdvhをsvhに変更する 

### DIFF
--- a/src/components/overlay/Modal.tsx
+++ b/src/components/overlay/Modal.tsx
@@ -8,7 +8,7 @@ export function Modal (props: {
   headerItem?: any;
 }) {
   const sideBarStyle = `right-0 w-80% max-w-100 h-[calc(100%-3.5rem)] border-(l-8 otdm-secondary) md:w-100 sm:(top-20)`;
-  const modalStyle = `w-full h-70vh m-auto border-(b-8 otdm-secondary) sm:(top-30 inset-x-0 w-80% max-w-220 h-80vh border-8 rounded-xl)`;
+  const modalStyle = `w-full h-60svh m-auto border-(b-8 otdm-secondary) sm:(top-30 inset-x-0 w-80% max-w-220 h-80svh border-8 rounded-xl)`;
   
   return (
     <Portal>

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -146,7 +146,7 @@ export default defineConfig({
     {
       'size-otdm-btn': 'size-8 sm:size-12',
       'size-otdm-icon': 'size-0.75em sm:size-1em',
-      'min-h-main' : 'min-h-[calc(100dvh-56px)] sm:min-h-[calc(100dvh-80px)]',
+      'min-h-main' : 'min-h-[calc(100svh-56px)] sm:min-h-[calc(100svh-80px)]',
       'mp-otdm': 'my-8 px-4 sm:(my-16 px-8)',
     },
     [


### PR DESCRIPTION
<!--issueの修正をする場合は必ず[Closes #`issue番号`]を先頭行に記入してください-->
Close #14 
## 説明

高さの単位であるvhとdvhをsvhに変更する 

## 追加される動作

モバイル端末の可変viewportの影響によりスタイルが不安定になる問題が修正された。

## 追記
