### PR TITLE
修正: search要素内のinput要素にhoverが適用されない問題を修正

### DIFF
--- a/src/components/overlay/search/Search.tsx
+++ b/src/components/overlay/search/Search.tsx
@@ -5,7 +5,7 @@ import { isSearchOpen } from "../overlay";
 
 export default function Search() {
   return (
-    <search class={`flex items-center btn-search-style sm:shadow-md rounded-lg ${isSearchOpen() && "outline-(3 solid)"}`} >
+    <search class={`flex items-center btn-search-style sm:shadow-md rounded-lg [&>input]:btn-search-style ${isSearchOpen() && "outline-(3 solid)"}`} >
       <Show when={isSearchOpen()}>
         <SearchModal/>
       </Show>

--- a/src/components/overlay/search/SearchModal.tsx
+++ b/src/components/overlay/search/SearchModal.tsx
@@ -48,7 +48,7 @@ export function SearchModal() {
     <>
       <input
         ref={inputRef}
-        class="block max-w-36 h-full p-2 m-auto text-lg btn-search-style focus:outline-unset placeholder-otdm-preh"
+        class="block max-w-36 h-full px-2 py-1 mx-2 my-auto text-lg focus:outline-unset placeholder-otdm-preh"
         type="search"
         placeholder="検索"
         value={query()}


### PR DESCRIPTION
<!--issueの修正をする場合は必ず[Closes #`issue番号`]を先頭行に記入してください-->
 Close #13
## 説明

 search要素内のinput要素にhoverが適用されない問題を修正した。
 子要素指定の記法を使用しました。
 
## 追加される動作

<!--このPRによって追加される動作を説明してください-->

## 追記
下記のブログが役立ちました。ありがとうございます。
<https://www.gaji.jp/blog/2022/10/19/11693/>